### PR TITLE
The `Monad` instance for `Moore` is inconsistent

### DIFF
--- a/src/Data/Machine/Moore.hs
+++ b/src/Data/Machine/Moore.hs
@@ -90,8 +90,8 @@ instance Pointed (Moore a) where
 instance Monad (Moore a) where
   return a = r where r = Moore a (const r)
   {-# INLINE return #-}
-  Moore a k >>= f = case f a of
-    Moore b _ -> Moore b (k >=> f)
+  k >>= f = j (fmap f k) where
+    j (Moore a g) = Moore (extract a) (\x -> j $ fmap (\(Moore _ h) -> h x) (g x))
   _ >> m = m
 
 instance Copointed (Moore a) where


### PR DESCRIPTION
``` haskell
import Control.Applicative
import Control.Monad
import Data.Machine.Moore

fromList :: [a] -> Moore b a
fromList (x:xs) = Moore x (const $ fromList xs)
fromList [] = error "end of stream"

toList :: Moore () a -> [a]
toList (Moore x f) = x : toList (f ())

foo = liftA2 (,) (fromList [0..]) (fromList [0,2..])

bar = liftM2 (,) (fromList [0..]) (fromList [0,2..])
```

```
> take 10 $ toList foo
[(0,0),(1,2),(2,4),(3,6),(4,8),(5,10),(6,12),(7,14),(8,16),(9,18)]
```

`bar` should be equivalent to `foo`, but the result went odd:

```
> take 10 $ toList bar
[(0,0),(1,0),(2,0),(3,0),(4,0),(5,0),(6,0),(7,0),(8,0),(9,0)]
```

I wrote (possibly) correct definition of `(>>=)`, and it seems to work well.
