### PR TITLE
Needs base >= 4.5 due to Data.Monoid.<>

### DIFF
--- a/machines.cabal
+++ b/machines.cabal
@@ -36,7 +36,7 @@ source-repository head
 
 library
   build-depends:
-    base         == 4.*,
+    base         >= 4.5   && < 5,
     comonad      >= 3     && < 5,
     containers   >= 0.3   && < 0.6,
     free         >= 3.1.1 && < 5,


### PR DESCRIPTION
```
src/Data/Machine/Type.hs:57:28:
    Module `Data.Monoid' does not export `(<>)'
```