### PR TITLE
Make `intersperse` easier to understand

### DIFF
--- a/src/Data/Machine/Process.hs
+++ b/src/Data/Machine/Process.hs
@@ -296,8 +296,8 @@ finalOr = construct . go where
 intersperse :: Category k => a -> Machine (k a) a
 intersperse sep = construct $ await >>= go where
   go cur = do
-    next <- await <|> yield cur *> stop
     yield cur
+    next <- await
     yield sep
     go next
 


### PR DESCRIPTION
Previously, the loop in `intersperse` would await a value before
yielding the current value, making it a bit tricky to emit the
last element. Simplified.