### PR TITLE
Add unfoldPlan for unfolding a 'stateful PlanT' into a MachineT from a start state.

### DIFF
--- a/src/Data/Machine/Type.hs
+++ b/src/Data/Machine/Type.hs
@@ -27,6 +27,7 @@ module Data.Machine.Type
   -- ** Building machines from plans
   , construct
   , repeatedly
+  , unfoldPlan
   , before
   , preplan
 --  , sink

--- a/src/Data/Machine/Type.hs
+++ b/src/Data/Machine/Type.hs
@@ -225,6 +225,15 @@ repeatedly m = r where
     (\f k g -> return (Await (MachineT #. f) k (MachineT g)))
     (return Stop)
 
+-- | Unfold a stateful PlanT into a MachineT.
+unfoldPlan :: Monad m => s -> (s -> PlanT k o m s) -> MachineT m k o
+unfoldPlan s0 sp = r s0 where
+  r s = MachineT $ runPlanT (sp s)
+      (\sx -> runMachineT $ r sx)
+      (\o k -> return (Yield o (MachineT k)))
+      (\f k g -> return (Await (MachineT #. f) k (MachineT g)))
+      (return Stop)
+
 -- | Evaluate a machine until it stops, and then yield answers according to the supplied model.
 before :: Monad m => MachineT m k o -> PlanT k o m a -> MachineT m k o
 before (MachineT n) m = MachineT $ runPlanT m


### PR DESCRIPTION
Works a bit like 'repeatedly', but the 'Done' value at the end of the
plan is used to spawn the next iteration of the plan.