### PR TITLE
Fix `stack` compilation with last Stackage LTS

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -30,6 +30,10 @@ generateBuildModule verbosity pkg lbi = do
     withTestLBI pkg lbi $ \suite suitecfg -> do
       rewriteFile (dir </> "Build_" ++ testName suite ++ ".hs") $ unlines
         [ "module Build_" ++ testName suite ++ " where"
+        , ""
+        , "autogen_dir :: String"
+        , "autogen_dir = " ++ show dir
+        , ""
         , "deps :: [String]"
         , "deps = " ++ (show $ formatdeps (testDeps libcfg suitecfg))
         ]

--- a/examples/machines-examples.cabal
+++ b/examples/machines-examples.cabal
@@ -23,8 +23,8 @@ source-repository head
 library
   build-depends:
     base         == 4.*,
-    machines     == 0.4,
-    mtl          >= 2 && < 2.2
+    machines     == 0.6,
+    mtl          >= 2 && < 2.3
 
   exposed-modules:
     Examples

--- a/machines.cabal
+++ b/machines.cabal
@@ -40,7 +40,7 @@ library
     base         >= 4.5   && < 5,
     comonad      >= 3     && < 5,
     containers   >= 0.3   && < 0.6,
-    distributive             < 0.5,
+    distributive             < 0.6,
     free         >= 3.1.1 && < 5,
     pointed      >= 3     && < 5,
     profunctors  >= 3     && < 6,
@@ -103,8 +103,8 @@ benchmark benchmarks
   build-depends:
     base                == 4.*,
     conduit             >= 1.0   && < 1.3,
-    conduit-combinators >= 0.2.5 && < 0.4,
-    criterion           >= 0.6   && < 1.1,
+    conduit-combinators >= 0.2.5 && < 1.1,
+    criterion           >= 0.6   && < 1.2,
     machines,
     mtl                 >= 2     && < 2.3,
     pipes               >= 4     && < 4.2

--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Build_doctests (deps)
+import Build_doctests (autogen_dir, deps)
 import Control.Applicative
 import Control.Monad
 import Data.List
@@ -12,9 +12,9 @@ import Prelude
 main :: IO ()
 main = getSources >>= \sources -> doctest $
     "-isrc"
-  : "-idist/build/autogen"
+  : ("-i" ++ autogen_dir)
   : "-optP-include"
-  : "-optPdist/build/autogen/cabal_macros.h"
+  : ("-optP" ++ autogen_dir ++ "/cabal_macros.h")
   : "-hide-all-packages"
   : map ("-package="++) deps ++ sources
 


### PR DESCRIPTION
Don't know if it's addressed by someone already but I need it to be fixed