### PR TITLE
Fix `stack repl`

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,1 +1,0 @@
-:set -isrc -idist/build/autogen -optP-include -optPdist/build/autogen/cabal_macros.h

--- a/machines.cabal
+++ b/machines.cabal
@@ -20,7 +20,6 @@ build-type:    Custom
 tested-with:   GHC == 7.4.1, GHC == 7.8.3
 extra-source-files:
   .travis.yml
-  .ghci
   .gitignore
   .vim.custom
   config


### PR DESCRIPTION
As the old `doctest` hack has been removed, I wonder if it's ok to get rid of `.ghci` as it prevents to `stack repl`