### PR TITLE
Process performance improvements

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -92,4 +92,9 @@ main =
   , bgroup "buffered"
       [ bench "machines" $ whnf drainM (M.buffered 1000)
       ]
+  , bgroup "concat"
+      [ bench "machines" $ whnf drainM (M.mapping (replicate 10) M.~> M.asParts)
+      , bench "pipes" $ whnf drainP (P.map (replicate 10) P.>-> P.concat)
+      , bench "conduit" $ whnf drainC (C.map (replicate 10) C.$= C.concat)
+      ]
   ]

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -79,11 +79,11 @@ main =
       ]
   , bgroup "zip"
       [ bench "machines" $ whnf (\x -> runIdentity $ M.runT_ x)
-                                (M.tee sourceM sourceM M.zipping)
+          (M.capT sourceM sourceM M.zipping)
       , bench "pipes" $ whnf (\x -> runIdentity $ P.runEffect $ P.for x P.discard)
-                             (P.zip sourceP sourceP)
+          (P.zip sourceP sourceP)
       , bench "conduit" $ whnf (\x -> runIdentity $ x C.$$ C.sinkNull)
-                               (C.getZipSource $ (,) <$> C.ZipSource sourceC <*> C.ZipSource sourceC)
+          (C.getZipSource $ (,) <$> C.ZipSource sourceC <*> C.ZipSource sourceC)
       ]
   , bgroup "last"
       [ bench "machines" $ whnf drainM (M.final)

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -23,7 +23,7 @@ drainC :: C.Conduit Int Identity a -> ()
 drainC c = runIdentity $ (sourceC C.$= c) C.$$ C.sinkNull
 
 drainSC :: C.Sink Int Identity b -> ()
-drainSC c = runIdentity $ void $ sourceC C.$$ c
+drainSC c = runIdentity $ void $! sourceC C.$$ c
 
 sourceM = M.enumerateFromTo 1 value
 sourceC = C.enumFromTo 1 value
@@ -55,12 +55,12 @@ main =
   , bgroup "take"
       [ bench "machines" $ whnf drainM (M.taking value)
       , bench "pipes" $ whnf drainP (P.take value)
-      , bench "conduit" $ whnf drainSC (C.take value)
+      , bench "conduit" $ whnf drainC (C.isolate value)
       ]
   , bgroup "takeWhile"
       [ bench "machines" $ whnf drainM (M.takingWhile (<= value))
       , bench "pipes" $ whnf drainP (P.takeWhile (<= value))
-      , bench "conduit" $ whnf drainSC (CC.takeWhile (<= value) C.=$= C.sinkNull)
+      , bench "conduit" $ whnf drainC (CC.takeWhile (<= value))
       ]
   , bgroup "fold"
       [ bench "machines" $ whnf drainM (M.fold (+) 0)

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -67,4 +67,19 @@ main =
       , bench "pipes" $ whnf (P.fold (+) 0 id) sourceP
       , bench "conduit" $ whnf drainSC (C.fold (+) 0)
       ]
+  , bgroup "filter"
+      [ bench "machines" $ whnf drainM (M.filtered even)
+      , bench "pipes" $ whnf drainP (P.filter even)
+      , bench "conduit" $ whnf drainC (C.filter even)
+      ]
+  , bgroup "mapM"
+      [ bench "machines" $ whnf drainM (M.autoM Identity)
+      , bench "pipes" $ whnf drainP (P.mapM Identity)
+      , bench "conduit" $ whnf drainC (C.mapM Identity)
+      ]
+  , bgroup "plan-test-machine"
+      [ bench "final" $ whnf drainM (M.final)
+      , bench "finalOr" $ whnf drainM (M.finalOr 0)
+      , bench "buffered" $ whnf drainM (M.buffered 1000)
+      ]
   ]

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import Control.Applicative
 import Control.Monad (void)
 import Control.Monad.Identity
 import Criterion.Main
@@ -9,6 +10,7 @@ import qualified Data.Conduit.List as C
 import qualified Data.Machine      as M
 import qualified Pipes             as P
 import qualified Pipes.Prelude     as P
+import Prelude
 
 value :: Int
 value = 1000000

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -33,7 +33,7 @@ main :: IO ()
 main =
   defaultMain
   [ bgroup "map"
-      [ bench "machines" $ whnf drainM (M.auto (+1))
+      [ bench "machines" $ whnf drainM (M.mapping (+1))
       , bench "pipes" $ whnf drainP (P.map (+1))
       , bench "conduit" $ whnf drainC (C.map (+1))
       ]

--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -22,7 +22,7 @@ slurpHandle h = clean <$> slurp where
   clean = either (\(SomeException _) -> []) id
   slurp = try $ do { s <- hGetLine h; (s:) <$> slurpHandle h }
 
--- read a file, returning each line in a list 
+-- read a file, returning each line in a list
 readLines :: FilePath -> IO [String]
 readLines f = withFile f ReadMode slurpHandle
 
@@ -41,8 +41,8 @@ slurpHandlePlan h = lift (slurpHandle h) >>= yield
  -}
 
 -- | getFileLines reads each line out of the given file and pumps them into the given process.
-getFileLines :: FilePath -> ProcessT IO String a -> SourceT IO a 
-getFileLines path proc = src ~> proc where 
+getFileLines :: FilePath -> ProcessT IO String a -> SourceT IO a
+getFileLines path proc = src ~> proc where
   src :: SourceT IO String
   src = construct $ lift (openFile path ReadMode) >>= slurpLinesPlan
   slurpLinesPlan :: Handle -> PlanT k String IO ()
@@ -97,7 +97,7 @@ uniq = run (supply xs uniqMachine) == [1,2,3] where
   -- (==)  means "groups are contiguous values"
   -- final means "run the 'final' machine over each group"
   uniqMachine :: (Monad m, Eq a) => ProcessT m a a
-  uniqMachine = groupingOn (==) final 
+  uniqMachine = groupingOn (==) final
 
   xs :: [Int]
   xs = [1,2,2,3,3,3]
@@ -109,6 +109,6 @@ def lineWordCount(fileName: String) =
 
 lineWordCount FilePath -> IO (Int, Int)
 lineWordCount path = runHead lineWordCountSrc where
-  lineWordCountSrc = echo 
+  lineWordCountSrc = echo
 -}
 

--- a/src/Data/Machine/Group.hs
+++ b/src/Data/Machine/Group.hs
@@ -25,7 +25,7 @@ taggedBy f = construct $ await >>= go
   where go x = do
           yield (Right x)
           y <- await
-          if not (f x y) then (yield (Left ()) >> go y) else go y
+          if not (f x y) then yield (Left ()) >> go y else go y
 
 
 -- | Run a machine multiple times over partitions of the input stream specified by

--- a/src/Data/Machine/Group.hs
+++ b/src/Data/Machine/Group.hs
@@ -16,9 +16,10 @@ groupingOn :: Monad m => (a -> a -> Bool) -> ProcessT m a b -> ProcessT m a b
 groupingOn f m = taggedBy f ~> partitioning m
 
 -- | Mark a transition point between two groups as a function of adjacent elements.
--- @
--- 'runT' ('supply' [1,2,2] ('taggedBy' (==))) == [Right 1, Left (), Right 2, Right 2]
--- @
+-- Examples
+--
+-- >>> runT $ supply [1,2,2] (taggedBy (==))
+-- [Right 1,Left (),Right 2,Right 2]
 taggedBy :: Monad m => (a -> a -> Bool) -> ProcessT m a (Either () a)
 taggedBy f = construct $ await >>= go
   where go x = do
@@ -27,7 +28,7 @@ taggedBy f = construct $ await >>= go
           if not (f x y) then (yield (Left ()) >> go y) else go y
 
 
--- | Run a machine multiple times over partitions of the input stream specified by 
+-- | Run a machine multiple times over partitions of the input stream specified by
 -- Left () values.
 partitioning :: Monad m => ProcessT m a b -> ProcessT m (Either () a) b
 partitioning s = go s where
@@ -54,5 +55,5 @@ partitioning s = go s where
 -- | input matching condition as first input of cont.
 -- | If await fails, stop.
 awaitUntil :: Monad m => (a -> Bool) -> (a -> ProcessT m a b) -> ProcessT m a b
-awaitUntil f cont = encased $ Await g Refl (encased Stop)
+awaitUntil f cont = encased $ Await g Refl stopped
   where g a = if f a then cont a else awaitUntil f cont

--- a/src/Data/Machine/MealyT.hs
+++ b/src/Data/Machine/MealyT.hs
@@ -18,7 +18,6 @@ module Data.Machine.MealyT
   , scanMealyT
   , scanMealyTM
   , embedMealyT
-  , autoT
   ) where
 
 import Data.Machine
@@ -28,6 +27,7 @@ import Data.Pointed
 import Control.Monad.Trans
 import Control.Monad.Identity
 import qualified Control.Category as C
+import Prelude
 
 -- | 'Mealy' machine, with monadic effects
 newtype MealyT m a b = MealyT { runMealyT :: a -> m (b, MealyT m a b) }
@@ -66,7 +66,7 @@ instance Monad m => Arrow (MealyT m) where
   arr f = r where r = MealyT (\a -> return (f a, r))
   first (MealyT m) = MealyT $ \(a,c) ->
     do (b, n) <- m a
-       return ((b, c), (first n))
+       return ((b, c), first n)
 
 arrPure :: (a -> b) -> MealyT Identity a b
 arrPure = arr

--- a/src/Data/Machine/Pipe.hs
+++ b/src/Data/Machine/Pipe.hs
@@ -123,7 +123,7 @@ fb' +>> pm = MachineT $ runMachineT pm >>= \p ->
 absurdExchange :: Exchange Void a b Void t -> c
 absurdExchange (Request z) = absurd z
 absurdExchange (Respond z) = absurd z
-                              
+
 -- | Run a self-contained 'Effect', converting it back to the base monad.
 runEffect :: Monad m => Effect m o -> m [o]
 runEffect (MachineT m) = m >>= \v ->

--- a/src/Data/Machine/Plan.hs
+++ b/src/Data/Machine/Plan.hs
@@ -168,7 +168,7 @@ instance MonadError e m => MonadError e (PlanT k o m) where
 yield :: o -> Plan k o ()
 yield o = PlanT (\kp ke _ _ -> ke o (kp ()))
 
--- | Like yield, except stops if there is no value to yield. 
+-- | Like yield, except stops if there is no value to yield.
 maybeYield :: Maybe o -> Plan k o ()
 maybeYield = maybe stop yield
 

--- a/src/Data/Machine/Process.hs
+++ b/src/Data/Machine/Process.hs
@@ -348,6 +348,13 @@ ma ~> mp = mp <~ ma
 {-# INLINABLE (~>) #-}
 
 -- | Feed a 'Process' some input.
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ supply [1,2,3] echo <~ source [4..6]
+-- [1,2,3,4,5,6]
+--
 supply :: forall f m a b . (Foldable f, Monad m) => f a -> ProcessT m a b -> ProcessT m a b
 supply xs = foldr go id xs
     where
@@ -453,6 +460,13 @@ scan1 func =
 -- |
 -- Like 'scan' only uses supplied function to map and uses Monoid for
 -- associative operation
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ mapping getSum <~ scanMap Sum <~ source [1..5]
+-- [0,1,3,6,10,15]
+--
 scanMap :: (Category k, Monoid b) => (a -> b) -> Machine (k a) b
 scanMap f = scan (\b a -> mappend b (f a)) mempty
 {-# INLINABLE scanMap #-}

--- a/src/Data/Machine/Process.hs
+++ b/src/Data/Machine/Process.hs
@@ -289,7 +289,7 @@ sinkPart_ :: Monad m => (a -> (b,c)) -> ProcessT m c Void -> ProcessT m a b
 sinkPart_ p = go
   where go m = MachineT $ runMachineT m >>= \v -> case v of
           Stop -> return Stop
-          Yield _ k -> runMachineT $ go k
+          Yield o _ -> absurd o
           Await f Refl ff -> return $
             Await (\x -> let (keep,sink) = p x
                          in encased . Yield keep $ go (f sink))

--- a/src/Data/Machine/Process.hs
+++ b/src/Data/Machine/Process.hs
@@ -58,10 +58,9 @@ module Data.Machine.Process
   , strippingPrefix
   ) where
 
-import Control.Applicative
 import Control.Category (Category)
 import Control.Arrow (Kleisli(..))
-import Control.Monad (liftM, when, replicateM_)
+import Control.Monad (liftM)
 import Control.Monad.Trans.Class
 import Data.Foldable hiding (fold)
 import Data.Machine.Is
@@ -71,7 +70,9 @@ import Data.Monoid
 import Data.Void
 import Prelude
 #if !(MIN_VERSION_base(4,8,0))
-  hiding (foldr)
+  hiding (id, (.), foldr)
+#else
+  hiding (id, (.))
 #endif
 
 -- $setup
@@ -98,9 +99,7 @@ class Automaton k where
   auto :: k a b -> Process a b
 
 instance Automaton (->) where
-  auto f = repeatedly $ do
-    i <- await
-    yield (f i)
+  auto = mapping
 
 instance Automaton Is where
   auto Refl = echo
@@ -115,52 +114,209 @@ instance AutomatonM Kleisli where
     yield r
 
 -- | The trivial 'Process' that simply repeats each input it receives.
+--
+-- This can be constructed from a plan with
+-- @
+-- echo :: Process a a
+-- echo = repeatedly $ do
+--   i <- await
+--   yield i
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ echo <~ source [1..5]
+-- [1,2,3,4,5]
+--
 echo :: Process a a
-echo = repeatedly $ do
-  i <- await
-  yield i
+echo =
+    loop
+  where
+    loop = encased (Await (\t -> encased (Yield t loop)) Refl stopped)
 
 -- | A 'Process' that prepends the elements of a 'Foldable' onto its input, then repeats its input from there.
 prepended :: Foldable f => f a -> Process a a
 prepended = before echo . traverse_ yield
 
 -- | A 'Process' that only passes through inputs that match a predicate.
+--
+-- This can be constructed from a plan with
+-- @
+-- filtered :: (a -> Bool) -> Process a a
+-- filtered p = repeatedly $ do
+--   i <- await
+--   when (p i) $ yield i
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ filtered even <~ source [1..5]
+-- [2,4]
+--
 filtered :: (a -> Bool) -> Process a a
-filtered p = repeatedly $ do
-  i <- await
-  when (p i) $ yield i
+filtered p =
+    loop
+  where
+    loop = encased
+         $ Await (\a -> case p a of
+            True  -> encased (Yield a loop)
+            False -> loop)
+           Refl
+           stopped
 
 -- | A 'Process' that drops the first @n@, then repeats the rest.
+--
+-- This can be constructed from a plan with
+-- @
+-- dropping n = before echo $ replicateM_ n await
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ dropping 3 <~ source [1..5]
+-- [4,5]
+--
 dropping :: Int -> Process a a
-dropping n = before echo $ replicateM_ n await
+dropping cnt0 =
+    loop cnt0
+  where
+    loop cnt
+      | cnt <= 0
+      = echo
+      | otherwise
+      = encased (Await (\_ -> loop (cnt - 1)) Refl stopped)
 
 -- | A 'Process' that passes through the first @n@ elements from its input then stops
+--
+-- This can be constructed from a plan with
+-- @
+-- taking n = construct . replicateM_ n $ await >>= yield
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ taking 3 <~ source [1..5]
+-- [1,2,3]
+--
 taking :: Int -> Process a a
-taking n = construct . replicateM_ n $ await >>= yield
+taking cnt0 =
+    loop cnt0
+  where
+    loop cnt
+      | cnt <= 0
+      = stopped
+      | otherwise
+      = encased (Await (\v -> encased $ Yield v (loop (cnt - 1))) Refl stopped)
 
 -- | A 'Process' that passes through elements until a predicate ceases to hold, then stops
+--
+-- This can be constructed from a plan with
+-- @
+-- takingWhile :: (a -> Bool) -> Process a a
+-- takingWhile p = repeatedly $ await >>= \v -> if p v then yield v else stop
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ takingWhile (< 3) <~ source [1..5]
+-- [1,2]
+--
 takingWhile :: (a -> Bool) -> Process a a
-takingWhile p = repeatedly $ await >>= \v -> if p v then yield v else stop
+takingWhile p =
+    loop
+  where
+    loop = encased
+         $ Await (\a -> case p a of
+            True  -> encased (Yield a loop)
+            False -> stopped)
+           Refl
+           stopped
 
 -- | A 'Process' that drops elements while a predicate holds
+--
+-- This can be constructed from a plan with
+-- @
+-- droppingWhile :: (a -> Bool) -> Process a a
+-- droppingWhile p = before echo loop where
+--   loop = await >>= \v -> if p v then loop else yield v
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ droppingWhile (< 3) <~ source [1..5]
+-- [3,4,5]
+--
 droppingWhile :: (a -> Bool) -> Process a a
-droppingWhile p = before echo loop where
-  loop = await >>= \v -> if p v then loop else yield v
+droppingWhile p =
+    loop
+  where
+    loop = encased
+         $ Await (\a -> case p a of
+            True  -> loop
+            False -> encased (Yield a echo))
+           Refl
+           stopped
 
 -- | Chunk up the input into `n` element lists.
 --
 -- Avoids returning empty lists and deals with the truncation of the final group.
+--
+-- An approximation of this can be constructed from a plan with
+-- @
+-- buffered :: Int -> Process a [a]
+-- buffered = repeatedly . go [] where
+--   go acc 0 = yield (reverse acc)
+--   go acc n = do
+--     i <- await <|> yield (reverse acc) *> stop
+--     go (i:acc) $! n-1
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ buffered 3 <~ source [1..6]
+-- [[1,2,3],[4,5,6]]
+--
+-- >>> run $ buffered 3 <~ source [1..5]
+-- [[1,2,3],[4,5]]
+--
+-- >>> run $ buffered 3 <~ source []
+-- []
+--
 buffered :: Int -> Process a [a]
-buffered = repeatedly . go [] where
-  go [] 0  = stop
-  go acc 0 = yield (reverse acc)
-  go acc n = do
-    i <- await <|> yield (reverse acc) *> stop
-    go (i:acc) $! n-1
+buffered n =
+    begin
+  where
+    -- The buffer is empty, if we don't get anything
+    -- then we shouldn't yield at all.
+    begin     = encased
+              $ Await (\v -> loop (v:) (n - 1))
+                      Refl
+                      stopped
 
--- | Alias to 'asParts'.
-flattened :: Foldable f => Process (f a) a
-flattened = asParts
+    -- The buffer (a diff list) contains elements, and
+    -- we're at the requisite number, yield the
+    -- buffer and restart
+    loop dl 0 = encased
+              $ Yield (dl []) begin
+
+    -- The buffer contains elements and we're not yet
+    -- done, continue waiting, but if we don't receive
+    -- anything, then yield what we have and stop.
+    loop dl r = encased
+              $ Await (\v -> loop (dl . (v:)) (r - 1))
+                      Refl
+                      (finish dl)
+
+    -- All data has been retrieved, emit and stop.
+    finish dl = encased
+              $ Yield (dl []) stopped
 
 -- | Build a new 'Machine' by adding a 'Process' to the output of an old 'Machine'
 --
@@ -176,7 +332,7 @@ mp <~ ma = MachineT $ runMachineT mp >>= \v -> case v of
   Await f Refl ff -> runMachineT ma >>= \u -> case u of
     Stop          -> runMachineT $ ff <~ stopped
     Yield o k     -> runMachineT $ f o <~ k
-    Await g kg fg -> return $ Await (\a -> MachineT (return v) <~ g a) kg (MachineT (return v) <~ fg)
+    Await g kg fg -> return $ Await (\a -> encased v <~ g a) kg (encased v <~ fg)
 
 -- | Flipped ('<~').
 (~>) :: Monad m => MachineT m k b -> ProcessT m b c -> MachineT m k c
@@ -221,27 +377,66 @@ process f (MachineT m) = MachineT (liftM f' m) where
 --
 -- Like 'fold', but yielding intermediate values.
 --
+-- It may be useful to consider this alternative signature
 -- @
 -- 'scan' :: (a -> b -> a) -> a -> Process b a
 -- @
 --
 -- For stateful 'scan' use 'auto' with "Data.Machine.Mealy" machine.
+-- This can be constructed from a plan with
+-- @
+-- scan :: Category k => (a -> b -> a) -> a -> Machine (k b) a
+-- scan func seed = construct $ go seed where
+--   go cur = do
+--     yield cur
+--     next <- await
+--     go $! func cur next
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ scan (+) 0 <~ source [1..5]
+-- [0,1,3,6,10,15]
 --
 scan :: Category k => (a -> b -> a) -> a -> Machine (k b) a
-scan func seed = construct $ go seed where
-  go cur = do
-    yield cur
-    next <- await
-    go $! func cur next
+scan func seed =
+  let step t = t `seq` encased
+             $ Yield t
+             $ encased
+             $ Await (step . func t)
+                     id
+                     stopped
+  in  step seed
 
 -- |
 -- 'scan1' is a variant of 'scan' that has no starting value argument
+--
+-- This can be constructed from a plan with
+-- @
+-- scan1 :: Category k => (a -> a -> a) -> Machine (k a) a
+-- scan1 func = construct $ await >>= go where
+--   go cur = do
+--     yield cur
+--     next <- await
+--     go $! func cur next
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ scan1 (+) <~ source [1..5]
+-- [1,3,6,10,15]
+--
 scan1 :: Category k => (a -> a -> a) -> Machine (k a) a
-scan1 func = construct $ await >>= go where
-  go cur = do
-    yield cur
-    next <- await
-    go $! func cur next
+scan1 func =
+  let step t = t `seq` encased
+             $ Yield t
+             $ encased
+             $ Await (step . func t)
+                     id
+                     stopped
+  in  encased $ Await step id stopped
 
 -- |
 -- Like 'scan' only uses supplied function to map and uses Monoid for
@@ -254,31 +449,75 @@ scanMap f = scan (\b a -> mappend b (f a)) mempty
 --
 -- Like 'scan', but only yielding the final value.
 --
+-- It may be useful to consider this alternative signature
 -- @
 -- 'fold' :: (a -> b -> a) -> a -> Process b a
 -- @
-fold :: Category k => (a -> b -> a) -> a -> Machine (k b) a
-fold func seed = construct $ go seed where
-  go cur = do
-    next <- await <|> yield cur *> stop
-    go $! func cur next
+--
+-- This can be constructed from a plan with
+-- @
+-- fold :: Category k => (a -> b -> a) -> a -> Machine (k b) a
+-- fold func seed = construct $ go seed where
+--   go cur = do
+--     next <- await <|> yield cur *> stop
+--     go $! func cur next
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ fold (+) 0 <~ source [1..5]
+-- [15]
+--
+fold :: Category k => (a -> a -> a) -> a -> Machine (k a) a
+fold func =
+  let step t = t `seq` encased
+             $ Await (step . func t)
+                     id
+                     (encased $ Yield t stopped)
+  in  step
 
 -- |
 -- 'fold1' is a variant of 'fold' that has no starting value argument
+--
+-- This can be constructed from a plan with
+-- @
+-- fold1 :: Category k => (a -> a -> a) -> Machine (k a) a
+-- fold1 func = construct $ await >>= go where
+--   go cur = do
+--     next <- await <|> yield cur *> stop
+--     go $! func cur next
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ fold1 (+) <~ source [1..5]
+-- [15]
+--
 fold1 :: Category k => (a -> a -> a) -> Machine (k a) a
-fold1 func = construct $ await >>= go where
-  go cur = do
-    next <- await <|> yield cur *> stop
-    go $! func cur next
+fold1 func =
+  let step t = t `seq` encased
+             $ Await (step . func t)
+                     id
+                     (encased $ Yield t stopped)
+  in  encased $ Await step id stopped
+
 
 -- | Break each input into pieces that are fed downstream
 -- individually.
 --
--- >>> run (asParts <~ source [[1,2], [3,4]])
--- [1,2,3,4]
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ asParts <~ source [[1..3],[4..6]]
+-- [1,2,3,4,5,6]
 --
 asParts :: Foldable f => Process (f a) a
 asParts = repeatedly $ await >>= traverse_ yield
+
+flattened :: Foldable f => Process (f a) a
+flattened = asParts
 
 -- | @sinkPart_ toParts sink@ creates a process that uses the
 -- @toParts@ function to break input into a tuple of @(passAlong,
@@ -297,33 +536,83 @@ sinkPart_ p = go
                   (go ff)
 
 -- | Apply a monadic function to each element of a 'ProcessT'.
+--
+-- This can be constructed from a plan with
+-- @
+-- autoM :: Monad m => (a -> m b) -> ProcessT m a b
+-- autoM :: (Category k, Monad m) => (a -> m b) -> MachineT m (k a) b
+-- autoM f = repeatedly $ await >>= lift . f >>= yield
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> runT $ autoM Left <~ source [3, 4]
+-- Left 3
+--
+-- >>> runT $ autoM Right <~ source [3, 4]
+-- Right [3,4]
+--
 autoM :: (Category k, Monad m) => (a -> m b) -> MachineT m (k a) b
-autoM f = repeatedly $ await >>= lift . f >>= yield
+autoM f =
+    loop
+  where
+    loop = encased (Await (\t -> MachineT (flip Yield loop `liftM` f t)) id stopped)
 
 -- |
 -- Skip all but the final element of the input
 --
+-- This can be constructed from a plan with
 -- @
 -- 'final' :: 'Process' a a
+-- final :: Category k => Machine (k a) a
+-- final = construct $ await >>= go where
+--   go prev = do
+--     next <- await <|> yield prev *> stop
+--     go next
 -- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> runT $ final <~ source [1..10]
+-- [10]
+-- >>> runT $ final <~ source []
+-- []
+--
 final :: Category k => Machine (k a) a
-final = construct $ await >>= go where
-  go prev = do
-    next <- await <|> yield prev *> stop
-    go next
+final =
+  let step x = encased (Await step id (emit x))
+      emit x = encased (Yield x stopped)
+  in encased $ Await step id stopped
 
 -- |
 -- Skip all but the final element of the input.
 -- If the input is empty, the default value is emitted
 --
+-- This can be constructed from a plan with
 -- @
 -- 'finalOr' :: a -> 'Process' a a
+-- finalOr :: Category k => a -> Machine (k a) a
+-- finalOr = construct . go where
+--   go prev = do
+--     next <- await <|> yield prev *> stop
+--     go next
 -- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> runT $ finalOr (-1) <~ source [1..10]
+-- [10]
+-- >>> runT $ finalOr (-1) <~ source []
+-- [-1]
+--
 finalOr :: Category k => a -> Machine (k a) a
-finalOr = construct . go where
-  go prev = do
-    next <- await <|> yield prev *> stop
-    go next
+finalOr o =
+  let step x = encased (Await step id (emit x))
+      emit x = encased (Yield x stopped)
+  in encased $ Await step id (emit o)
 
 -- |
 -- Intersperse an element between the elements of the input
@@ -351,23 +640,56 @@ smallest = fold1 min
 
 -- |
 -- Convert a stream of actions to a stream of values
+--
+-- This can be constructed from a plan with
+-- @
+-- sequencing :: Monad m => (a -> m b) -> ProcessT m a b
+-- sequencing :: (Category k, Monad m) => MachineT m (k (m a)) a
+-- sequencing = repeatedly $ do
+--   ma <- await
+--   a  <- lift ma
+--   yield a
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> runT $ sequencing <~ source [Just 3, Nothing]
+-- Nothing
+--
+-- >>> runT $ sequencing <~ source [Just 3, Just 4]
+-- Just [3,4]
+--
 sequencing :: (Category k, Monad m) => MachineT m (k (m a)) a
-sequencing = repeatedly $ do
-  ma <- await
-  a  <- lift ma
-  yield a
+sequencing = autoM id
 
 -- |
 -- Apply a function to all values coming from the input
+--
+-- This can be constructed from a plan with
+-- @
+-- mapping :: Category k => (a -> b) -> Machine (k a) b
+-- mapping f = repeatedly $ await >>= yield . f
+-- @
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> runT $ mapping (*2) <~ source [1..3]
+-- [2,4,6]
+--
 mapping :: Category k => (a -> b) -> Machine (k a) b
-mapping f = repeatedly $ await >>= yield . f
+mapping f =
+    loop
+  where
+    loop = encased (Await (\t -> encased (Yield (f t) loop)) id stopped)
 
 -- |
 -- Apply an effectful to all values coming from the input.
 --
 -- Alias to 'autoM'.
 traversing :: (Category k, Monad m) => (a -> m b) -> MachineT m (k a) b
-traversing f = repeatedly $ await >>= lift . f >>= yield
+traversing = autoM
 
 -- |
 -- Parse 'Read'able values, only emitting the value if the parse succceeds.
@@ -404,5 +726,6 @@ strippingPrefix mp mb = MachineT $ runMachineT mp >>= \v -> case v of
         | b == b'   -> runMachineT $ strippingPrefix nxt nxt'
         | otherwise -> return Stop
       Await f ki ff ->
-        return $ Await (\a -> MachineT $ verify b nxt (f a))
-                   ki (MachineT $ verify b nxt ff)
+        return $ Await (MachineT . verify b nxt . f)
+                       ki
+                       (MachineT $ verify b nxt ff)

--- a/src/Data/Machine/Process.hs
+++ b/src/Data/Machine/Process.hs
@@ -532,9 +532,14 @@ fold1 func =
   in  encased $ Await step id stopped
 {-# INLINABLE fold1 #-}
 
-
 -- | Break each input into pieces that are fed downstream
 -- individually.
+--
+-- This can be constructed from a plan with
+-- @
+-- asParts :: Foldable f => Process (f a) a
+-- asParts = repeatedly $ await >>= traverse_ yield
+-- @
 --
 -- Examples:
 --
@@ -543,7 +548,13 @@ fold1 func =
 -- [1,2,3,4,5,6]
 --
 asParts :: Foldable f => Process (f a) a
-asParts = repeatedly $ await >>= traverse_ yield
+asParts =
+  let step = encased
+           $ Await (foldr (\b s -> encased (Yield b s)) step)
+                   id
+                   stopped
+  in  step
+{-# INLINABLE asParts #-}
 
 flattened :: Foldable f => Process (f a) a
 flattened = asParts

--- a/src/Data/Machine/Source.hs
+++ b/src/Data/Machine/Source.hs
@@ -95,7 +95,7 @@ cycled xs = foldr go (cycled xs) xs
 -- [1,2]
 --
 source :: Foldable f => f b -> Source b
-source xs = foldr go stopped xs
+source = foldr go stopped
   where
     go x m = encased $ Yield x m
 

--- a/src/Data/Machine/Source.hs
+++ b/src/Data/Machine/Source.hs
@@ -31,7 +31,7 @@ import Data.Foldable
 import Data.Machine.Plan
 import Data.Machine.Type
 import Data.Machine.Process
-import Prelude (Enum, Eq, Int, Maybe, Monad, ($))
+import Prelude (Enum, Int, Maybe, Monad, ($))
 
 -------------------------------------------------------------------------------
 -- Source
@@ -128,7 +128,7 @@ replicated n x = repeated x ~> taking n
 -- >>> run $ enumerateFromTo 1 3
 -- [1,2,3]
 --
-enumerateFromTo :: (Enum a, Eq a) => a -> a -> Source a
+enumerateFromTo :: Enum a => a -> a -> Source a
 enumerateFromTo start end = source [ start .. end ]
 
 -- | 'unfold' @k seed@ The function takes the element and returns Nothing if it

--- a/src/Data/Machine/Stack.hs
+++ b/src/Data/Machine/Stack.hs
@@ -33,16 +33,17 @@ peek = do
   a <- pop
   push a
   return a
+{-# INLINABLE peek #-}
 
 -- | Push back into the input stream
 push :: a -> Plan (Stack a) b ()
 push a = awaits (Push a)
+{-# INLINABLE push #-}
 
 -- | Pop the next value in the input stream
 pop :: Plan (Stack a) b a
 pop = awaits Pop
-
--- TODO: make this a class?
+{-# INLINABLE pop #-}
 
 -- | Stream outputs from one 'Machine' into another with the possibility
 -- of pushing inputs back.
@@ -60,3 +61,4 @@ stack up down =
         Yield o up'          -> up'     `stack` down' o
         Await up' req ffU    -> encased (Await (\a -> up' a `stack` encased stepD) req
                                                (      ffU   `stack` encased stepD))
+{-# INLINABLE stack #-}

--- a/src/Data/Machine/Tee.hs
+++ b/src/Data/Machine/Tee.hs
@@ -17,7 +17,7 @@ module Data.Machine.Tee
   , T(..)
   , tee, teeT
   , addL, addR
-  , capL, capR
+  , capL, capR, capT
   , zipWithT
   , zipWith
   , zipping
@@ -28,7 +28,7 @@ import Data.Machine.Plan
 import Data.Machine.Process
 import Data.Machine.Type
 import Data.Machine.Source
-import Prelude hiding ((.),id, zipWith)
+import Prelude hiding ((.), id, zipWith)
 
 -------------------------------------------------------------------------------
 -- Tees
@@ -113,6 +113,13 @@ capL s t = fit cappedT $ addL s t
 capR :: Monad m => SourceT m b -> TeeT m a b c -> ProcessT m a c
 capR s t = fit cappedT $ addR s t
 {-# INLINE capR #-}
+
+-- | Tie off both inputs to a tee by connecting them to known sources.
+--   This is recommended over capping each side separately, as it is
+--   far more efficient.
+capT :: Monad m => SourceT m a -> SourceT m b -> TeeT m a b c -> SourceT m c
+capT l r t = plug $ tee l r t
+{-# INLINE capT #-}
 
 -- | Natural transformation used by 'capL' and 'capR'.
 cappedT :: T a a b -> Is a b

--- a/src/Data/Machine/Tee.hs
+++ b/src/Data/Machine/Tee.hs
@@ -46,6 +46,13 @@ type Tee a b c = Machine (T a b) c
 type TeeT m a b c = MachineT m (T a b) c
 
 -- | Compose a pair of pipes onto the front of a Tee.
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ tee (source [1..]) (source ['a'..'c']) zipping
+-- [(1,'a'),(2,'b'),(3,'c')]
+--
 tee :: Monad m => ProcessT m a a' -> ProcessT m b b' -> TeeT m a' b' c -> TeeT m a b c
 tee ma mb m = MachineT $ runMachineT m >>= \v -> case v of
   Stop         -> return Stop
@@ -62,7 +69,16 @@ tee ma mb m = MachineT $ runMachineT m >>= \v -> case v of
       return $ Await (\b -> tee ma (g b) $ encased v) R $ tee ma fg $ encased v
 
 -- | `teeT mt ma mb` Use a `Tee` to interleave or combine the outputs of `ma`
---   and `mb`
+--   and `mb`.
+--
+--   The resulting machine will draw from a single source.
+--
+-- Examples:
+--
+-- >>> import Data.Machine.Source
+-- >>> run $ teeT zipping echo echo <~ source [1..5]
+-- [(1,2),(3,4)]
+--
 teeT :: Monad m => TeeT m a b c -> MachineT m k a -> MachineT m k b -> MachineT m k c
 teeT mt ma mb = MachineT $ runMachineT mt >>= \v -> case v of
   Stop         -> return Stop

--- a/src/Data/Machine/Type.hs
+++ b/src/Data/Machine/Type.hs
@@ -261,10 +261,13 @@ preplan m = MachineT $ runPlanT m
 -- 'pass' 'Data.Machine.Wye.Y'  :: 'Data.Machine.Wye.Wye' a b b
 -- 'pass' 'Data.Machine.Wye.Z'  :: 'Data.Machine.Wye.Wye' a b (Either a b)
 -- @
+--
 pass :: k o -> Machine k o
-pass k = repeatedly $ do
-  a <- awaits k
-  yield a
+pass k =
+    loop
+  where
+    loop = encased (Await (\t -> encased (Yield t loop)) k stopped)
+
 
 
 -- | Run a machine with no input until it stops, then behave as another machine.

--- a/src/Data/Machine/Wye.hs
+++ b/src/Data/Machine/Wye.hs
@@ -18,7 +18,7 @@ module Data.Machine.Wye
   , Y(..)
   , wye
   , addX, addY
-  , capX, capY
+  , capX, capY, capWye
   ) where
 
 import Control.Category
@@ -85,20 +85,25 @@ addX :: Monad m => ProcessT m a b -> WyeT m b c d -> WyeT m a c d
 addX p = wye p echo
 {-# INLINE addX #-}
 
--- | Precompose a pipe onto the right input of a tee.
+-- | Precompose a pipe onto the right input of a wye.
 addY :: Monad m => ProcessT m b c -> WyeT m a c d -> WyeT m a b d
 addY = wye echo
 {-# INLINE addY #-}
 
--- | Tie off one input of a tee by connecting it to a known source.
+-- | Tie off one input of a wye by connecting it to a known source.
 capX :: Monad m => SourceT m a -> WyeT m a b c -> ProcessT m b c
 capX s t = process (capped Right) (addX s t)
 {-# INLINE capX #-}
 
--- | Tie off one input of a tee by connecting it to a known source.
+-- | Tie off one input of a wye by connecting it to a known source.
 capY :: Monad m => SourceT m b -> WyeT m a b c -> ProcessT m a c
 capY s t = process (capped Left) (addY s t)
 {-# INLINE capY #-}
+
+-- | Tie off both inputs of a wye by connecting them to known sources.
+capWye :: Monad m => SourceT m a -> SourceT m b -> WyeT m a b c -> SourceT m c
+capWye a b = plug . wye a b
+{-# INLINE capWye #-}
 
 -- | Natural transformation used by 'capX' and 'capY'
 capped :: (a -> Either a a) -> Y a a b -> a -> b


### PR DESCRIPTION
This one might be a little controversial, but I did some experiments rewriting `Process` and `Source` `Machines` explicitly instead of using a `Plan` and got performance improvements essentially across the board.
I also believe there were some bugs in `buffered`, as there were situations where it would lead to empty list outputs.

This does make these machines less readable and harder to fathom however.

Here's a handful of before and afters

Edit: Further improvements below with inlining.
