### PR TITLE
Make machines forward-Wcompat clean

### DIFF
--- a/machines.cabal
+++ b/machines.cabal
@@ -84,6 +84,13 @@ library
     UndecidableInstances
 
   ghc-options: -Wall -fwarn-tabs -O2 -fdicts-cheap -funbox-strict-fields
+
+  -- See https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#base-4.9.0.0
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+  else
+    build-depends: fail == 4.9.*
+
   hs-source-dirs: src
 
 -- Verify the results of the examples

--- a/src/Data/Machine/Is.hs
+++ b/src/Data/Machine/Is.hs
@@ -15,7 +15,7 @@ module Data.Machine.Is
   ) where
 
 import Control.Category
-import Data.Monoid
+import Data.Semigroup
 import Prelude
 
 -- | Witnessed type equality
@@ -33,10 +33,14 @@ instance Ord (Is a b) where
   Refl `compare` Refl = EQ
   {-# INLINE compare #-}
 
+instance (a ~ b) => Semigroup (Is a b) where
+  Refl <> Refl = Refl
+  {-# INLINE (<>) #-}
+
 instance (a ~ b) => Monoid (Is a b) where
   mempty = Refl
   {-# INLINE mempty #-}
-  mappend Refl Refl = Refl
+  mappend = (<>)
   {-# INLINE mappend #-}
 
 instance (a ~ b) => Read (Is a b) where

--- a/src/Data/Machine/Mealy.hs
+++ b/src/Data/Machine/Mealy.hs
@@ -95,12 +95,12 @@ unfoldMealy f = go where
 
 -- | slow diagonalization
 instance Monad (Mealy a) where
-  return b = r where r = Mealy (const (b, r))
+  return = pure
   {-# INLINE return #-}
   m >>= f = Mealy $ \a -> case runMealy m a of
     (b, m') -> (fst (runMealy (f b) a), m' >>= f)
   {-# INLINE (>>=) #-}
-  _ >> n = n
+  (>>) = (*>)
   {-# INLINE (>>) #-}
 
 instance Profunctor Mealy where

--- a/src/Data/Machine/MealyT.hs
+++ b/src/Data/Machine/MealyT.hs
@@ -49,8 +49,12 @@ instance Applicative m => Applicative (MealyT m a) where
   MealyT m <*> MealyT n = MealyT $ \a -> (\(mb, mm) (nb, nm) -> (mb nb, mm <*> nm)) <$> m a <*> n a
 
 instance Monad m => Monad (MealyT m a) where
+#if !MIN_VERSION_base(4,8,0)
+  -- pre-AMP
   {-# INLINE return #-}
   return b = r where r = MealyT (const (return (b, r))) -- Stolen from Pointed
+#endif
+
   MealyT g >>= f = MealyT $ \a ->
     do (b, MealyT _h) <- g a
        runMealyT (f b) a

--- a/src/Data/Machine/Moore.hs
+++ b/src/Data/Machine/Moore.hs
@@ -98,11 +98,11 @@ instance Pointed (Moore a) where
 
 -- | slow diagonalization
 instance Monad (Moore a) where
-  return a = r where r = Moore a (const r)
+  return = pure
   {-# INLINE return #-}
   k >>= f = j (fmap f k) where
     j (Moore a g) = Moore (extract a) (\x -> j $ fmap (\(Moore _ h) -> h x) (g x))
-  _ >> m = m
+  (>>) = (*>)
 
 instance Copointed (Moore a) where
   copoint (Moore b _) = b

--- a/src/Data/Machine/Plan.hs
+++ b/src/Data/Machine/Plan.hs
@@ -39,6 +39,7 @@ import Control.Monad.IO.Class
 import Control.Monad.State.Class
 import Control.Monad.Reader.Class
 import Control.Monad.Error.Class
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Writer.Class
 import Data.Functor.Identity
 import Prelude hiding ((.),id)
@@ -114,10 +115,13 @@ instance Monad (PlanT k o m) where
   return = pure
   {-# INLINE return #-}
   PlanT m >>= f = PlanT (\kp ke kr kf -> m (\a -> runPlanT (f a) kp ke kr kf) ke kr kf)
+  {-# INLINE (>>=) #-}
   (>>) = (*>)
   {-# INLINE (>>) #-}
+  fail = Fail.fail
+
+instance Fail.MonadFail (PlanT k o m) where
   fail _ = PlanT (\_ _ _ kf -> kf)
-  {-# INLINE (>>=) #-}
 
 instance MonadPlus (PlanT k o m) where
   mzero = empty


### PR DESCRIPTION
This makes `machines` forward-compat with all those 3-letter acronym
proposals (i.e. AMP, MFP, MRP, SMP).

NB: This may require a minor version bump, as new instances of `Semigroup` & `MonadFail` were defined!