### PR TITLE
Add more benchmarks and improve performance

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -87,16 +87,16 @@ main =
       , bench "conduit" $ whnf (\x -> runIdentity $ x C.$$ C.sinkNull)
           (C.getZipSource $ (,) <$> C.ZipSource sourceC <*> C.ZipSource sourceC)
       ]
+  , bgroup "concat"
+      [ bench "machines" $ whnf drainM (M.mapping (replicate 10) M.~> M.asParts)
+      , bench "pipes" $ whnf drainP (P.map (replicate 10) P.>-> P.concat)
+      , bench "conduit" $ whnf drainC (C.map (replicate 10) C.$= C.concat)
+      ]
   , bgroup "last"
       [ bench "machines" $ whnf drainM (M.final)
       , bench "pipes" $ whnf P.last sourceP
       ]
   , bgroup "buffered"
       [ bench "machines" $ whnf drainM (M.buffered 1000)
-      ]
-  , bgroup "concat"
-      [ bench "machines" $ whnf drainM (M.mapping (replicate 10) M.~> M.asParts)
-      , bench "pipes" $ whnf drainP (P.map (replicate 10) P.>-> P.concat)
-      , bench "conduit" $ whnf drainC (C.map (replicate 10) C.$= C.concat)
       ]
   ]

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import Control.Applicative
+import Data.Function ((&))
 import Control.Monad (void)
 import Control.Monad.Identity
 import Criterion.Main
@@ -10,6 +11,7 @@ import qualified Data.Conduit.List as C
 import qualified Data.Machine      as M
 import qualified Pipes             as P
 import qualified Pipes.Prelude     as P
+import qualified Streaming.Prelude as S
 import Prelude
 
 value :: Int
@@ -27,61 +29,77 @@ drainC c = runIdentity $ (sourceC C.$= c) C.$$ C.sinkNull
 drainSC :: C.Sink Int Identity b -> ()
 drainSC c = runIdentity $ void $! sourceC C.$$ c
 
+drainS :: (S.Stream (S.Of Int) Identity () -> S.Stream (S.Of Int) Identity ())
+    -> ()
+drainS s = runIdentity $ S.effects $ sourceS & s
+
 sourceM = M.enumerateFromTo 1 value
 sourceC = C.enumFromTo 1 value
 sourceP = P.each [1..value]
+sourceS = S.each [1..value]
 
 main :: IO ()
 main =
   defaultMain
   [ bgroup "map"
       [ bench "machines" $ whnf drainM (M.mapping (+1))
+      , bench "streaming" $ whnf drainS (S.map (+1))
       , bench "pipes" $ whnf drainP (P.map (+1))
       , bench "conduit" $ whnf drainC (C.map (+1))
       ]
   , bgroup "drop"
       [ bench "machines" $ whnf drainM (M.dropping value)
+      , bench "streaming" $ whnf drainS (S.drop value)
       , bench "pipes" $ whnf drainP (P.drop value)
       , bench "conduit" $ whnf drainC (C.drop value)
       ]
   , bgroup "dropWhile"
       [ bench "machines" $ whnf drainM (M.droppingWhile (<= value))
+      , bench "streaming" $ whnf drainS (S.dropWhile (<= value))
       , bench "pipes" $ whnf drainP (P.dropWhile (<= value))
       , bench "conduit" $ whnf drainC (CC.dropWhile (<= value))
       ]
   , bgroup "scan"
       [ bench "machines" $ whnf drainM (M.scan (+) 0)
+      , bench "streaming" $ whnf drainS (S.scan (+) 0 id)
       , bench "pipes" $ whnf drainP (P.scan (+) 0 id)
       , bench "conduit" $ whnf drainC (CC.scanl (+) 0)
       ]
   , bgroup "take"
       [ bench "machines" $ whnf drainM (M.taking value)
+      , bench "streaming" $ whnf drainS (S.take value)
       , bench "pipes" $ whnf drainP (P.take value)
       , bench "conduit" $ whnf drainC (C.isolate value)
       ]
   , bgroup "takeWhile"
       [ bench "machines" $ whnf drainM (M.takingWhile (<= value))
+      , bench "streaming" $ whnf drainS (S.takeWhile (<= value))
       , bench "pipes" $ whnf drainP (P.takeWhile (<= value))
       , bench "conduit" $ whnf drainC (CC.takeWhile (<= value))
       ]
   , bgroup "fold"
       [ bench "machines" $ whnf drainM (M.fold (+) 0)
+      , bench "streaming" $ whnf (S.fold (+) 0 id) sourceS
       , bench "pipes" $ whnf (P.fold (+) 0 id) sourceP
       , bench "conduit" $ whnf drainSC (C.fold (+) 0)
       ]
   , bgroup "filter"
       [ bench "machines" $ whnf drainM (M.filtered even)
+      , bench "streaming" $ whnf drainS (S.filter even)
       , bench "pipes" $ whnf drainP (P.filter even)
       , bench "conduit" $ whnf drainC (C.filter even)
       ]
   , bgroup "mapM"
       [ bench "machines" $ whnf drainM (M.autoM Identity)
+      , bench "streaming" $ whnf drainS (S.mapM Identity)
       , bench "pipes" $ whnf drainP (P.mapM Identity)
       , bench "conduit" $ whnf drainC (C.mapM Identity)
       ]
   , bgroup "zip"
       [ bench "machines" $ whnf (\x -> runIdentity $ M.runT_ x)
           (M.capT sourceM sourceM M.zipping)
+      , bench "streaming" $ whnf (\x -> runIdentity $ S.effects $ x)
+          (S.zip sourceS sourceS)
       , bench "pipes" $ whnf (\x -> runIdentity $ P.runEffect $ P.for x P.discard)
           (P.zip sourceP sourceP)
       , bench "conduit" $ whnf (\x -> runIdentity $ x C.$$ C.sinkNull)
@@ -89,11 +107,13 @@ main =
       ]
   , bgroup "concat"
       [ bench "machines" $ whnf drainM (M.mapping (replicate 10) M.~> M.asParts)
+      , bench "streaming" $ whnf drainS (S.concat . S.map (replicate 10))
       , bench "pipes" $ whnf drainP (P.map (replicate 10) P.>-> P.concat)
       , bench "conduit" $ whnf drainC (C.map (replicate 10) C.$= C.concat)
       ]
   , bgroup "last"
       [ bench "machines" $ whnf drainM (M.final)
+      , bench "streaming" $ whnf S.last sourceS
       , bench "pipes" $ whnf P.last sourceP
       ]
   , bgroup "buffered"

--- a/machines.cabal
+++ b/machines.cabal
@@ -118,4 +118,5 @@ benchmark benchmarks
     criterion           >= 0.6   && < 1.3,
     machines,
     mtl                 >= 2     && < 2.3,
-    pipes               >= 4     && < 4.4
+    pipes               >= 4     && < 4.4,
+    streaming           >= 0.1.4 && < 0.1.5

--- a/src/Data/Machine/Type.hs
+++ b/src/Data/Machine/Type.hs
@@ -164,6 +164,7 @@ appliedTo mis blocking ss f g m n = MachineT $ runMachineT m >>= \v -> case v of
 -}
 
 -- | Stop feeding input into model, taking only the effects.
+{-# INLINABLE runT_ #-}
 runT_ :: Monad m => MachineT m k b -> m ()
 runT_ m = runMachineT m >>= \v -> case v of
   Stop        -> return ()
@@ -171,6 +172,7 @@ runT_ m = runMachineT m >>= \v -> case v of
   Await _ _ e -> runT_ e
 
 -- | Stop feeding input into model and extract an answer
+{-# INLINABLE runT #-}
 runT :: Monad m => MachineT m k b -> m [b]
 runT (MachineT m) = m >>= \v -> case v of
   Stop        -> return []


### PR DESCRIPTION
Significant changes include:

1) Added comparison with "streaming" package which seems to be better than pipes and conduit in most cases.
2) Added benchmarks to compare `toList` APIs
3) Added a composite benchmark to measure performance when multiple ops are composed together
4) Added benchmarks to measure perf in the IO monad. 
5) Improve performance of `toList` and the composite benchmarks by inlining `runT` and `runT_`

The inlining change made the `toList` benchmarks at par or better than others. It improved the composite benchmarks as well quite a bit but they are still worse off than other packages. Especially the IO monad case (`CompositeIO` benchmark) seems to be pretty bad - `streaming` takes 46 ms whereas machines takes 313 ms.