### PR TITLE
Remove Monad instances from Mealy and MealyT

### DIFF
--- a/examples/machines-examples.cabal
+++ b/examples/machines-examples.cabal
@@ -32,7 +32,7 @@ source-repository head
 library
   build-depends:
     base         == 4.*,
-    machines     == 0.6.*,
+    machines     == 0.7.*,
     mtl          >= 2 && < 2.3
 
   exposed-modules:

--- a/machines.cabal
+++ b/machines.cabal
@@ -1,6 +1,6 @@
 name:          machines
 category:      Control, Enumerator
-version:       0.6.4
+version:       0.7.0
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE


### PR DESCRIPTION
Fixes #103

Upgrade notes:
* Use liftA2 instead of mzipWith