### PR TITLE
Fix GHC 8.6 noncanonical-monoid-instances warnings.

### DIFF
--- a/src/Data/Machine/Mealy.hs
+++ b/src/Data/Machine/Mealy.hs
@@ -207,4 +207,4 @@ instance Semigroup b => Semigroup (Mealy a b) where
 
 instance Monoid b => Monoid (Mealy a b) where
   mempty = Mealy mempty
-  mappend f g = Mealy $ \x -> runMealy f x `mappend` runMealy g x
+  mappend = (<>)

--- a/src/Data/Machine/Mealy.hs
+++ b/src/Data/Machine/Mealy.hs
@@ -5,6 +5,10 @@
 #ifndef MIN_VERSION_profunctors
 #define MIN_VERSION_profunctors(x,y,z) 0
 #endif
+
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 0
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Machine.Mealy
@@ -205,6 +209,10 @@ instance Closed Mealy where
 instance Semigroup b => Semigroup (Mealy a b) where
   f <> g = Mealy $ \x -> runMealy f x <> runMealy g x
 
+#if MIN_VERSION_base(4,11,0)
 instance Monoid b => Monoid (Mealy a b) where
+#else
+instance (Semigroup b, Monoid b) => Monoid (Mealy a b) where
+#endif
   mempty = Mealy mempty
   mappend = (<>)

--- a/src/Data/Machine/Moore.hs
+++ b/src/Data/Machine/Moore.hs
@@ -161,4 +161,4 @@ instance Semigroup b => Semigroup (Moore a b) where
 
 instance Monoid b => Monoid (Moore a b) where
   mempty = Moore mempty mempty
-  Moore x f `mappend` Moore y g = Moore (x `mappend` y) (f `mappend` g)
+  mappend = (<>)

--- a/src/Data/Machine/Moore.hs
+++ b/src/Data/Machine/Moore.hs
@@ -5,6 +5,10 @@
 #ifndef MIN_VERSION_profunctors
 #define MIN_VERSION_profunctors(x,y,z) 0
 #endif
+
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 0
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Machine.Moore
@@ -159,6 +163,10 @@ instance Closed Moore where
 instance Semigroup b => Semigroup (Moore a b) where
   Moore x f <> Moore y g = Moore (x <> y) (f <> g)
 
-instance Monoid b => Monoid (Moore a b) where
+#if MIN_VERSION_base(4,11,0)
+instance (Monoid b) => Monoid (Moore a b) where
+#else
+instance (Semigroup b, Monoid b) => Monoid (Moore a b) where
+#endif
   mempty = Moore mempty mempty
   mappend = (<>)


### PR DESCRIPTION
When compiling with `-Wall`, GHC warns if a `Monoid` instance defines
`mappend` as something other than an alias for `<>`. The `Monoid`
instances for Moore and Mealy machines defined their own `mappend`
implementations, though they did not differ semantically from `<>`.

This replaces those `mappend` definitions with `<>`.