### PR TITLE
Fix the Representable instance of Moore.

### DIFF
--- a/src/Data/Machine/Moore.hs
+++ b/src/Data/Machine/Moore.hs
@@ -139,8 +139,7 @@ instance Costrong Moore where
 
 instance Profunctor.Corepresentable Moore where
   type Corep Moore = []
-  cotabulate f0 = go (f0 . reverse) where
-    go f = Moore (f []) $ \a -> go (f.(a:))
+  cotabulate f = Moore (f []) $ \a -> cotabulate (f.(a:))
 
 instance MonadFix (Moore a) where
   mfix = mfixRep


### PR DESCRIPTION
The current instance doesn't satisfy the law `index . tabulate ≡ id`:
```haskell
>>> index (tabulate id :: Moore Int [Int]) [1,2,3]
[3,2,1]
```
I think `index` is correct, so `tabulate` needs to be fixed.